### PR TITLE
Add TradLeap to Referrals section

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ If you would like to contribute to this growing list, please submit a PR.
 
 * [ReferralCandy](https://www.referralcandy.com/)
 - [Channable](https://www.channable.com/)
+* [TradLeap](https://tradeleap.io/)
 
 ## Project Management / Productivity
 


### PR DESCRIPTION
Added [TradLeap](https://tradeleap.io/) to the Referrals section.

TradLeap is an affiliate and reseller management platform for Shopify stores. It helps e-commerce businesses build and manage partner networks with commission tracking and automated payouts.