### PR TITLE
Add ViewIGStory to Instagram section

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ If you would like to contribute to this growing list, please submit a PR.
 * [IconoSquare](https://pro.iconosquare.com/)
 * [Link Big](http://www.link-big.com/)
 * [Buffer](https://buffer.com/)
+* [ViewIGStory](https://www.view-ig-story.com/) — Anonymous Instagram story viewer for competitor research; observe how competing stores tell stories without leaving a trace.
 
 ## Facebook
 


### PR DESCRIPTION
Adds **ViewIGStory** (https://www.view-ig-story.com) to the Instagram section.

Anonymous Instagram story viewer for e-commerce competitor research — observe how competing stores tell stories on Instagram (product launches, promo cadence, story-CTA patterns) without leaving a trace in their viewer list.

Complements the existing Instagram entries (Liketoknow.it, IconoSquare, Link Big, Buffer) by covering the competitor-research angle specifically.

Single-line entry. Inserted after Buffer.